### PR TITLE
Markup User logout page

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,3 +11,4 @@
 @import "modules/other-items";
 @import "modules/profile";
 @import "modules/purchase";
+@import "modules/logout";

--- a/app/assets/stylesheets/modules/logout.scss
+++ b/app/assets/stylesheets/modules/logout.scss
@@ -1,0 +1,16 @@
+.mypage__logout {
+  padding: 64px;
+  background-color: #fff;
+  &__btn {
+    display: block;
+    margin: 0 auto;
+    width: 320px;
+    height: 50px;
+    background: #ea352d;
+    border: 1px solid #ea352d;
+    color: #fff;
+    font-size: 14px;
+    text-align: center;
+    line-height: 50px;
+  }
+}

--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -13,4 +13,7 @@ class TestController < ApplicationController
 
   def purchase
   end
+
+  def logout
+  end
 end

--- a/app/views/test/logout.html.haml
+++ b/app/views/test/logout.html.haml
@@ -1,0 +1,25 @@
+.container
+  = render 'shared/header'
+  .profile-header
+    %ul
+      %li
+        = link_to "#", class: "profile-header__link" do
+          メルカリ
+          = icon 'fas', 'chevron-right', class: 'profile-header__link__icon'
+      %li
+        = link_to "#", class: "profile-header__link" do
+          マイページ
+          = icon 'fas', 'chevron-right', class: 'profile-header__link__icon'
+      %li
+        = link_to "#", class: "profile-header__link" do
+          ログアウト
+
+  .contents.clearfix
+    = render partial: "mypage-side"
+    .mypage
+      .mypage__logout
+        = link_to '#', class: 'mypage__logout__btn' do
+          ログアウト
+
+  = render 'shared/banner'
+  = render 'shared/footer'

--- a/app/views/test/logout.html.haml
+++ b/app/views/test/logout.html.haml
@@ -23,3 +23,4 @@
 
   = render 'shared/banner'
   = render 'shared/footer'
+  = render 'shared/footer-sellBtn'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get 'test', to: 'test#index'
   get 'test/mypage', to: 'test#mypage', as: 'mypage'
   get 'test/mypage/profile', to: 'test#profile'
+  get 'test/mypage/logout', to: 'test#logout'
   get 'test/purchase', to: 'test#purchase', as: 'purchase'
   root 'test#index'
   get 'detail', to: 'test#detail'


### PR DESCRIPTION
## What
ユーザーログアウトページのマークアップ

## Why
ユーザー用のログアウト導線および、ボタンを実装するため。

![Markup-user-logout-page ](https://user-images.githubusercontent.com/48905598/59751715-006a8a80-92bc-11e9-8aed-d35e85df97f3.png)

## 実装内容
- mypage/logout
  - ルーティングおよびコントローラーは仮置き
- ヘッダー、サイドバー、バナー、フッター、出品ボタンはテンプレート
- パンくずはユーザープロフィール編集ページで作成したものを使用