### PR TITLE
とりあえずの複数画像投稿機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,40 +13,24 @@ class ItemsController < ApplicationController
 
   def create
     @categories = Category.all
-    @item = Item.new(to_int_category_id)
-    @item.item_images.build
-    # @item = Item.create(name: params[:name], price: params[:price], text: params[:text])
-
-    # binding.pry
-     if @item.save
+    @item = Item.new(item_params)
+    if @item.save
+      params[:item_images][:image].each do |url|
+        @item.item_images.create(url: url, item_id: @item.id)
+      end
       redirect_to root_path, notice: '出品しました。'
-     #else
-       #render "items/new"
-     end
+    end
   end
 
   private
   def item_params
-    params.require(:item).permit(:name, :price, :text, :category_id, :condition, :delivery_charge, :prefecture_id, :estimated_shipping_date, item_images_attributes: [:url])
+    params.require(:item).permit(:name, :price, :text, :category_id, :condition, :delivery_charge, :delivery_method, :prefecture_id, :estimated_shipping_date, :sales_status, item_images_attributes: [:url])
   end
 
-  def to_int_category_id
-    item_params.tap do |ip|
-      ip[:category_id] = ip[:category_id].to_i
-    end
-  end
-
-  # private
-  # def item_params
-  #   params.require(:item).permit(
-  #     :name,
-  #     :text,
-  #     :condition,
-  #     :delivery_charge,
-  #     # :delivery_method,
-  #     :prefecture_id,
-  #     :estimated_shipping_date,
-  #     :price
-  #   )
+  #下記コードは何してるかわからない
+  # def to_int_category_id
+  #   item_params.tap do |ip|
+  #     ip[:category_id] = ip[:category_id].to_i
+  #   end
   # end
 end

--- a/app/views/shared/_item-registration.html.haml
+++ b/app/views/shared/_item-registration.html.haml
@@ -9,8 +9,8 @@
           %span.form-require 必須
         %p 最大10枚までアップロードできます
         .wrapper__main__image__drop-box
-          = f.fields_for :item_images do |f|
-            = f.file_field :url
+          = f.fields_for :item_images do |image|
+            = image.file_field :url, multiple: true, name: 'item_images[image][]', id: "upload-image", class: "upload-image", 'data-image': 0
           %p ドラッグアンドドロップ
           %p またはクリックしてファイルをアップロード
         - if @image_error.present?
@@ -34,7 +34,7 @@
             %p
               カテゴリー
               %span.form-require 必須
-            .wrapper__main__list__select__wrap 
+            .wrapper__main__list__select__wrap
               = f.collection_select :category_id, @categories, :id, :name, { prompt: '---' }, autofocus: true, class: 'item-registration__form__group__box__select__body'
               -# %select
               -#   %option ---
@@ -56,7 +56,7 @@
             %p
               商品の状態
               %span.form-require 必須
-            .wrapper__main__list__select__wrap 
+            .wrapper__main__list__select__wrap
               =f.select :condition, Item.conditions_i18n.invert, {}
               %i.fas.fa-chevron-down
       .wrapper__main__list__delivery
@@ -64,13 +64,20 @@
           %p
             配送について
             %span.fa.fa-question-circle
-        .wrapper__main__list__select__box 
+        .wrapper__main__list__select__box
           .wrapper__main__list__select__top
             %p
               配送料の負担
               %span.form-require 必須
-            .wrapper__main__list__select__wrap 
+            .wrapper__main__list__select__wrap
               =f.select :delivery_charge, Item.delivery_charges_i18n.invert, {}
+              %i.fas.fa-chevron-down
+          .wrapper__main__list__select__top
+            %p
+              配送の方法
+              %span.form-require 必須
+            .wrapper__main__list__select__wrap
+              =f.select :delivery_method, Item.delivery_methods_i18n.invert, {}
               %i.fas.fa-chevron-down
           .wrapper__main__list__select__center
             %p
@@ -83,8 +90,15 @@
             %p
               発送までの日数
               %span.form-require 必須
-            .wrapper__main__list__select__wrap 
+            .wrapper__main__list__select__wrap
               =f.select :estimated_shipping_date , Item.estimated_shipping_dates_i18n.invert, {}
+              %i.fas.fa-chevron-down
+          .wrapper__main__list__select__bottom
+            %p
+              sales_status
+              %span.form-require 必須
+            .wrapper__main__list__select__wrap
+              =f.select :sales_status , Item.sales_statuses_i18n.invert, {}
               %i.fas.fa-chevron-down
       .wrapper__main__list__price
         .wrapper__main__list__name
@@ -117,6 +131,6 @@
         %a また、出品を持ちまして
         %a.blue 加盟店規約
         %a に同意したことになります。
-        %button.wrapper__main__bottom__red 
+        %button.wrapper__main__bottom__red
           =f.submit "出品する"
         %button.wrapper__main__bottom__grey もどる


### PR DESCRIPTION
## what
とりあえずの複数画像投稿
item_sell_functionへのマージプルリク

DB環境を再構築しなおすのがめんどくさかったので、delivery_method と sales_status カラムを無理やりビューに追加してやってます。（ビュー崩れまくり）

## 変更ファイル
- items_controller.rb
  - to_int_category_idアクションはどういう動きしてるやつなのかわからなかったのでコメントアウト
- _item-registration.html.haml

↓ここを参考に実装
https://qiita.com/shinnosuke960801/items/66f2a511803d7dac53a3