### PR TITLE
Item detail page fix

### DIFF
--- a/app/assets/stylesheets/modules/items.scss
+++ b/app/assets/stylesheets/modules/items.scss
@@ -25,7 +25,7 @@
       &--item {
         margin: 0 0 0 20px;
         width: 213px;
-        height: 330px;
+        height: 360px;
         .item-link {
           display: block;
           text-decoration: none;
@@ -39,7 +39,7 @@
           }
           &__text {
             padding: 16px;
-            height: 100%;
+            height: 144px;
             box-sizing: border-box;
             background-color: #fff;
             &--header {

--- a/app/assets/stylesheets/modules/other-items.scss
+++ b/app/assets/stylesheets/modules/other-items.scss
@@ -17,7 +17,7 @@
       display: flex;
       &--item {
         width: 213px;
-        height: 330px;
+        height: 360px;
         margin: 0 12px;
         .item-link {
           display: block;
@@ -32,7 +32,7 @@
           }
           &__text {
             padding: 16px;
-            height: 110px;
+            height: 144px;
             box-sizing: border-box;
             background-color: #fff;
             &--header {

--- a/app/views/shared/_other-items.html.haml
+++ b/app/views/shared/_other-items.html.haml
@@ -15,7 +15,7 @@
                 = otherItem.name
               .item-link__text--price
                 .price
-                  ='¥ ' + number_with_delimiter("#{@item.price}")
+                  ='¥ ' + number_with_delimiter("#{otherItem.price}")
                 .likes
                   = icon('far', 'heart', class: 'likes__icon')
                   %span.likes__rate
@@ -40,7 +40,7 @@
                 = sameCategories.name
               .item-link__text--price
                 .price
-                  ='¥ ' + number_with_delimiter("#{@item.price}")
+                  ='¥ ' + number_with_delimiter("#{sameCategories.price}")
                 .likes
                   = icon('far', 'heart', class: 'likes__icon')
                   %span.likes__rate

--- a/app/views/shared/_other-items.html.haml
+++ b/app/views/shared/_other-items.html.haml
@@ -1,49 +1,51 @@
-%section.other-items-container
-  %section.other-items
-    %h3.other-items__head
-      = link_to '#', class: 'other-items__head--link' do
-        = @item.saler.nickname
-        のその他の出品
-    .other-items__box
-      - @otherItems.each do |otherItem|
-        %section.other-items__box--item
-          = link_to item_path(otherItem.id), class: 'item-link' do
-            .item-link__image-box
-              = image_tag "#{otherItem.item_images.first.url}", alt: 'item-name', class: 'item-image'
-            .item-link__text
-              %h3.item-link__text--header
-                = otherItem.name
-              .item-link__text--price
-                .price
-                  ='¥ ' + number_with_delimiter("#{otherItem.price}")
-                .likes
-                  = icon('far', 'heart', class: 'likes__icon')
-                  %span.likes__rate
-                    10
-              %p.item-link__text--tax
-                (税込)
+- if @otherItems.present?
+  %section.other-items-container
+    %section.other-items
+      %h3.other-items__head
+        = link_to '#', class: 'other-items__head--link' do
+          = @item.saler.nickname
+          のその他の出品
+      .other-items__box
+        - @otherItems.each do |otherItem|
+          %section.other-items__box--item
+            = link_to item_path(otherItem.id), class: 'item-link' do
+              .item-link__image-box
+                = image_tag "#{otherItem.item_images.first.url}", alt: 'item-name', class: 'item-image'
+              .item-link__text
+                %h3.item-link__text--header
+                  = otherItem.name
+                .item-link__text--price
+                  .price
+                    ='¥ ' + number_with_delimiter("#{otherItem.price}")
+                  .likes
+                    = icon('far', 'heart', class: 'likes__icon')
+                    %span.likes__rate
+                      10
+                %p.item-link__text--tax
+                  (税込)
 
-%section.other-items-container
-  %section.other-items
-    %h3.other-items__head
-      = link_to '#', class: 'other-items__head--link' do
-        = @item.category.name
-        のその他の出品
-    .other-items__box
-      - @sameCategories.each do |sameCategories|
-        %section.other-items__box--item
-          = link_to item_path(sameCategories.id), class: 'item-link' do
-            .item-link__image-box
-              = image_tag "#{sameCategories.item_images.first.url}", alt: 'item-name', class: 'item-image'
-            .item-link__text
-              %h3.item-link__text--header
-                = sameCategories.name
-              .item-link__text--price
-                .price
-                  ='¥ ' + number_with_delimiter("#{sameCategories.price}")
-                .likes
-                  = icon('far', 'heart', class: 'likes__icon')
-                  %span.likes__rate
-                    10
-              %p.item-link__text--tax
-                (税込)
+- if @sameCategories.present?
+  %section.other-items-container
+    %section.other-items
+      %h3.other-items__head
+        = link_to '#', class: 'other-items__head--link' do
+          = @item.category.name
+          のその他の出品
+      .other-items__box
+        - @sameCategories.each do |sameCategories|
+          %section.other-items__box--item
+            = link_to item_path(sameCategories.id), class: 'item-link' do
+              .item-link__image-box
+                = image_tag "#{sameCategories.item_images.first.url}", alt: 'item-name', class: 'item-image'
+              .item-link__text
+                %h3.item-link__text--header
+                  = sameCategories.name
+                .item-link__text--price
+                  .price
+                    ='¥ ' + number_with_delimiter("#{sameCategories.price}")
+                  .likes
+                    = icon('far', 'heart', class: 'likes__icon')
+                    %span.likes__rate
+                      10
+                %p.item-link__text--tax
+                  (税込)


### PR DESCRIPTION
## what
- トップページおよび商品詳細ページのビュー崩れ改善
- 商品詳細ページの出品ユーザーの「その他の出品」「同じカテゴリーの出品」がない場合、ビューに表示させない

## why
ビュー崩れ改善、ユーザーにとって紛らわしい表示の排除