### PR TITLE
Edit sns authenticate

### DIFF
--- a/app/assets/stylesheets/modules/registration.scss
+++ b/app/assets/stylesheets/modules/registration.scss
@@ -252,6 +252,7 @@ li.current-page {
 .registration-main {
   &__head--adress {
     @include registration-head(10px, 24px);
+    font-weight: bold;
   }
 }
 
@@ -264,7 +265,8 @@ li.current-page {
 //payment
 .registration-main {
   &__head--payment {
-    @include registration-head(10px, 24px)
+    @include registration-head(10px, 24px);
+    font-weight: bold;
   }
 }
 .registration-form__credit-img {

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,8 +7,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if session[:sns_user].present?
       @sns_user = User.new(nickname: session[:sns_user]["nickname"],
                        email: session[:sns_user]["email"],
+                       password: Devise.friendly_token[0, 20],
                        uid: session[:sns_user]["uid"],
                        provider: session[:sns_user]["provider"])
+      session[:sns_password] = @sns_user.password
       session[:sns_user] = nil
     else
       @sns_user = User.new
@@ -22,7 +24,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def create
     @user = User.new(session[:user])
+    if session[:sns_password]
+      @user.password = @user.password_confirmation = session[:sns_password]
+      session[:sns_password] = nil
+    end
+
     @user.profile = @user.build_profile(session[:profile])
+
     if @user.save
       sign_up(@user, current_user)
       session[:user] = nil

--- a/app/views/devise/registrations/registration.html.haml
+++ b/app/views/devise/registrations/registration.html.haml
@@ -34,14 +34,15 @@
             = f.email_field :email, value: @sns_user.email, placeholder: 'PC・携帯どちらでも可', class: 'input-default', required: true
           = f.hidden_field :uid, value: @sns_user.uid
           = f.hidden_field :provider, value: @sns_user.provider
-          .registration-form__group
-            = f.label :password, 'パスワード'
-            %span.require 必須
-            = f.password_field :password, placeholder: '6文字以上', class: 'input-default', required: true, minlength: '6'
-          .registration-form__group
-            = f.label :password_confirmation, 'パスワード(確認)'
-            %span.require 必須
-            = f.password_field :password_confirmation, placeholder: '6文字以上', class: 'input-default', required: true, minlength: '6'
+          - unless @sns_user.uid && @sns_user.provider
+            .registration-form__group
+              = f.label :password, 'パスワード'
+              %span.require 必須
+              = f.password_field :password, placeholder: '6文字以上', class: 'input-default', required: true, minlength: '6'
+            .registration-form__group
+              = f.label :password_confirmation, 'パスワード(確認)'
+              %span.require 必須
+              = f.password_field :password_confirmation, placeholder: '6文字以上', class: 'input-default', required: true, minlength: '6'
           .registration-form__group
             .registration-form__group__confirmation
               %h3


### PR DESCRIPTION
# What
SNS認証でのユーザー新規登録時にパスワードの設定を省くように修正

# Why
SNS認証ではログイン時にSNS側でユーザーの認証を行うためパスワードの入力が必要ない
そのため新規登録時もユーザー側がパスワードを設定する必要がないため

## 実装内容
sns認証時にパスワードを自動で生成
会員情報入力ページではパスワード入力欄を非表示にする

https://drive.google.com/file/d/1_4EeLWg78ffhngfvwpRR5fxvtdHQvtUU/view?usp=sharing